### PR TITLE
fix __radd__ for sum usage

### DIFF
--- a/poly_commit/bls/fields.py
+++ b/poly_commit/bls/fields.py
@@ -24,10 +24,8 @@ class Fq:
             return NotImplemented
         return Fq(self.Q, self.value + other.value)
 
-    def __radd__(self, other: Fq) -> Fq:
-        if not isinstance(other, Fq):
-            return NotImplemented
-        return self.__add__(other)
+    def __radd__(self, other: int) -> Fq:
+        return self.__add__(Fq(self.Q, other))
 
     def __sub__(self, other: Fq) -> Fq:
         if not isinstance(other, Fq):

--- a/poly_commit/bls/fields.py
+++ b/poly_commit/bls/fields.py
@@ -25,6 +25,8 @@ class Fq:
         return Fq(self.Q, self.value + other.value)
 
     def __radd__(self, other: int) -> Fq:
+        if not isinstance(other, int):
+            return NotImplemented
         return self.__add__(Fq(self.Q, other))
 
     def __sub__(self, other: Fq) -> Fq:


### PR DESCRIPTION
When I try to `sum` a list of finite field elements:
```
yz = sum([coeff[i] * Fq(order, pow(z, i, order)) for i in range(len(coeff))])
```
> note: coeff is a list fo Fq

, it give me the following error:
> TypeError: unsupported operand type(s) for +: 'int' and 'Fq'

I find the bug comes from the the too strong constraint in the following code:
https://github.com/qizhou/research/blob/84ef6048238305fee529348cb08d576aed80d447/poly_commit/bls/fields.py#L27-L30

The `sum` function,`sum(iterable, /, start=0)` is tricky. It will sum the default start integer zero with the items of an iterable from left to right. So when it applied to Fq,`0+Fq(order, value)`, the default start integer zero don't know the Fq class. Thus, the error come out.

When the add operator is overrided in class, it seems like the reverse add `__radd___` is commonly used to solve this kind of problem [^2]. When it come across `0+Fq`, the `__add__` fails, and the `__radd___` function will be tried to solve it with the changes `0+Fq` to `Fq+0` by leveraging the commutative property of addition.

## Reference

1. [sum Built-in Functions — Python 3.11.4 documentation](https://docs.python.org/3/library/functions.html#sum)

2. [^2][Operator Overloading in Python [Article] | Treehouse Blog](https://blog.teamtreehouse.com/operator-overloading-python#:~:text=HTML%20Before%20Python%3F-,Reverse%20Adding,-So%20the)
