### PR TITLE
Several Improvements

### DIFF
--- a/op/fdg_watcher.py
+++ b/op/fdg_watcher.py
@@ -5,6 +5,7 @@ import argparse
 import smtplib
 from email.message import EmailMessage
 
+
 FORMAT = "%(asctime)-15s %(message)s"
 logging.basicConfig(format=FORMAT)
 logging.getLogger("jsonrpcclient.client.request").setLevel(logging.WARNING)
@@ -32,7 +33,7 @@ def get_blocknumber(url):
         "params": [],
         "id": 1,
     }
-    
+
     response = requests.post(url, json=payload)
 
     result = response.json()
@@ -45,7 +46,7 @@ def get_fdg_games(url, addr, from_block):
         "params": [{"address": addr, "topics": ["0x5b565efe82411da98814f356d0e7bcb8f0219b8d970307c5afb4a6903a8b2e35"], "fromBlock": hex(from_block), "toBlock": "finalized" }],
         "id": 1,
     }
-    
+
     response = requests.post(url, json=payload)
 
     return response.json()["result"]
@@ -57,7 +58,7 @@ def get_fdg_game_info(url, txhash):
         "params": [txhash],
         "id": 1,
     }
-    
+
     response = requests.post(url, json=payload)
     input = response.json()["result"]["input"]
 
@@ -70,7 +71,7 @@ def get_l2output(url, blocknum):
         "params": [hex(blocknum)],
         "id": 1,
     }
-    
+
     response = requests.post(url, json=payload)
 
     result = response.json()["result"]
@@ -142,7 +143,6 @@ def main():
     parser.add_argument("--username", type=str, default="", help="email username")
     parser.add_argument("--password", type=str, default="", help="email password")
     parser.add_argument("--test_email", action="store_true", help="send a test email when start")
-    
     args = parser.parse_args()
 
     # prev_balance = None

--- a/op/fdg_watcher.py
+++ b/op/fdg_watcher.py
@@ -140,7 +140,6 @@ def main():
     parser.add_argument("--username", type=str, default="", help="email username")
     parser.add_argument("--password", type=str, default="", help="email password")
     parser.add_argument("--test_email", type=bool, default=False, help="send a test email when start")
-    parser.add_argument("--recipient", type=str, default="", help="email recipient")
     
     args = parser.parse_args()
 
@@ -148,7 +147,7 @@ def main():
     prev_send = time.monotonic()
 
     if args.test_email:
-        title = "test email for {}".format(args.recipient)
+        title = "test email for fdg watcher {}".format(args.fdg_factory)
         send_email(title, "", args.from_addr, args.to_addr, args.username, args.password)
 
     try:

--- a/op/fdg_watcher.py
+++ b/op/fdg_watcher.py
@@ -165,7 +165,14 @@ def main():
             games = get_fdg_games(args.l1_rpc, args.fdg_factory, bn - args.blocks)
 
             for g in games:
-                info = get_fdg_game_info(args.l1_rpc, g["transactionHash"])                    
+                info = get_fdg_game_info(args.l1_rpc, g["transactionHash"])
+                # Skip if blockNumber is 0 or output is missing
+                if info["blockNumber"] == 0 or not info["output"]:
+                    logger.warning(f"Skipping game check due to missing data: {g['transactionHash']}")                                    
+                    skipped_count += 1
+                    skipped_games.append(g["transactionHash"])
+                    continue
+                
                 l2output = get_l2output(args.l2_rpc, info["blockNumber"])
                 if l2output != "0x" + info["output"]:
                     # If the output roots don't match, check if the game is blacklisted

--- a/op/fdg_watcher.py
+++ b/op/fdg_watcher.py
@@ -209,6 +209,9 @@ def main():
                     # If the output roots don't match, check if the game is blacklisted
                     # Game address is in the second topic, where the last 40 characters represent the address
                     game_topics = g["topics"]
+                    # Initialize game_address with a default value in case we can't extract it
+                    game_address = "0x0"
+                    
                     if len(game_topics) >= 2:
                         # Extract the address part (last 40 characters) from the second topic
                         topic_data = game_topics[1]
@@ -218,7 +221,8 @@ def main():
                     
                     blacklisted = False
                     
-                    if args.optimism_portal2 and game_address:
+                    # Only check blacklist if we have a valid game address (not the default)
+                    if args.optimism_portal2 and game_address != "0x0":
                         blacklisted = is_game_blacklisted(args.l1_rpc, args.optimism_portal2, game_address)
                         if blacklisted:
                             logger.info(f"Game {game_address} has output mismatch but is blacklisted, skipping alert")

--- a/op/fdg_watcher.py
+++ b/op/fdg_watcher.py
@@ -162,7 +162,7 @@ def main():
         "--check_interval", type=int, default=15 * 60, help="interval to query"
     )
     parser.add_argument(
-        "--force_interval", type=int, default=None, help="interval to forcibly send update"
+        "--force_interval", type=int, default=3600 * 24, help="interval to forcibly send update"
     )
     parser.add_argument(
         "--blocks", type=int, default=7*7200, help="starting block (now - interval)"

--- a/op/fdg_watcher.py
+++ b/op/fdg_watcher.py
@@ -152,8 +152,8 @@ def main():
         title = "test email for fdg watcher {}".format(args.fdg_factory)
         send_email(title, "", args.from_addr, args.to_addr, args.username, args.password)
 
-    try:
-        while True:
+    while True:
+        try:
             logger.info("Checking")
             errors = 0
             blacklisted_count = 0  # Counter for blacklisted games
@@ -215,13 +215,16 @@ def main():
                 send_email(title, msg, args.from_addr, args.to_addr, args.username, args.password)
                 prev_send = time.monotonic()
 
-            time.sleep(args.check_interval)
-    except KeyboardInterrupt:
-        logger.info("Exiting due to keyboard interrupt (Ctrl+C)")
-        # Perform any cleanup here if needed
+            logger.info(f"Checking complete. Waiting {args.check_interval} seconds before next check.")
+        except KeyboardInterrupt:
+            logger.info("Exiting due to keyboard interrupt (Ctrl+C)")
+            break  # Exit the while loop on Ctrl+C
+        except Exception as e:
+            logger.error(f"Error in main loop: {str(e)}")
+            logger.info("Continuing to next iteration...")
+        
+        # Sleep is outside the try-except block so it always happens, even after errors
+        time.sleep(args.check_interval)
 
 if __name__ == "__main__":
-    try:
-        main()
-    except KeyboardInterrupt:
-        logger.info("Exiting due to keyboard interrupt (Ctrl+C)")
+    main()

--- a/op/fdg_watcher.py
+++ b/op/fdg_watcher.py
@@ -99,7 +99,7 @@ def is_game_blacklisted(url, portal_address, game_address):
     response = requests.post(url, json=payload)
     result = response.json().get("result", "0x")
     
-    # If result is 0x or 0x0, the game is not blacklisted
+    # If result is 0x00, the game is not blacklisted
     # If result is 0x01, the game is blacklisted
     if result == "0x":
         logger.warning(f"Unexpected result from disputeGameBlacklist: {result}")

--- a/op/fdg_watcher.py
+++ b/op/fdg_watcher.py
@@ -32,11 +32,15 @@ def get_blocknumber(url):
         "params": [],
         "id": 1,
     }
-
-    response = requests.post(url, json=payload)
-
-    result = response.json()
-    return int(result['result'], 16)
+    
+    try:
+        response = requests.post(url, json=payload)
+        response.raise_for_status()  # Raises exception for 4XX/5XX responses
+        result = response.json()
+        return int(result['result'], 16)
+    except requests.RequestException as e:
+        logger.error(f"Error in get_blocknumber: {e}")
+        raise
 
 def get_fdg_games(url, addr, from_block):
     payload = {
@@ -45,10 +49,15 @@ def get_fdg_games(url, addr, from_block):
         "params": [{"address": addr, "topics": ["0x5b565efe82411da98814f356d0e7bcb8f0219b8d970307c5afb4a6903a8b2e35"], "fromBlock": hex(from_block), "toBlock": "finalized" }],
         "id": 1,
     }
-
-    response = requests.post(url, json=payload)
-
-    return response.json()["result"]
+    
+    try:
+        response = requests.post(url, json=payload)
+        response.raise_for_status()
+        result = response.json()
+        return result.get("result", [])
+    except requests.RequestException as e:
+        logger.error(f"Error in get_fdg_games: {e}")
+        return []
 
 def get_fdg_game_info(url, txhash):
     payload = {
@@ -57,11 +66,20 @@ def get_fdg_game_info(url, txhash):
         "params": [txhash],
         "id": 1,
     }
-
-    response = requests.post(url, json=payload)
-    input = response.json()["result"]["input"]
-
-    return {"output": input[10+64:10+2*64], "blockNumber": int(input[10+4*64:10+5*64], 16)}
+    
+    try:
+        response = requests.post(url, json=payload)
+        response.raise_for_status()
+        result = response.json()
+        if not result.get("result"):
+            logger.error(f"No result returned for transaction {txhash}")
+            return {"output": "", "blockNumber": 0}
+            
+        input = result["result"]["input"]
+        return {"output": input[10+64:10+2*64], "blockNumber": int(input[10+4*64:10+5*64], 16)}
+    except (requests.RequestException, KeyError, ValueError) as e:
+        logger.error(f"Error in get_fdg_game_info for tx {txhash}: {e}")
+        return {"output": "", "blockNumber": 0}
 
 def get_l2output(url, blocknum):
     payload = {
@@ -70,11 +88,19 @@ def get_l2output(url, blocknum):
         "params": [hex(blocknum)],
         "id": 1,
     }
-
-    response = requests.post(url, json=payload)
-
-    result = response.json()["result"]
-    return result["outputRoot"]
+    
+    try:
+        response = requests.post(url, json=payload)
+        response.raise_for_status()
+        result = response.json()
+        if not result.get("result"):
+            logger.error(f"No result returned for block {blocknum}")
+            return "0x"
+            
+        return result["result"]["outputRoot"]
+    except (requests.RequestException, KeyError) as e:
+        logger.error(f"Error in get_l2output for block {blocknum}: {e}")
+        return "0x"
 
 def is_game_blacklisted(url, portal_address, game_address):
     # Create function signature for disputeGameBlacklist(IDisputeGame)
@@ -96,15 +122,21 @@ def is_game_blacklisted(url, portal_address, game_address):
         "id": 1
     }
     
-    response = requests.post(url, json=payload)
-    result = response.json().get("result", "0x")
-    
-    # If result is 0x00, the game is not blacklisted
-    # If result is 0x01, the game is blacklisted
-    if result == "0x":
-        logger.warning(f"Unexpected result from disputeGameBlacklist: {result}")
-    else:
-        return result.strip() == "0x01" or result.strip() == "0x0000000000000000000000000000000000000000000000000000000000000001"
+    try:
+        response = requests.post(url, json=payload)
+        response.raise_for_status()
+        result = response.json().get("result", "0x")
+        
+        # If result is 0x00, the game is not blacklisted
+        # If result is 0x01, the game is blacklisted
+        if result == "0x":
+            logger.warning(f"Unexpected result from disputeGameBlacklist: {result}")
+            return False
+        else:
+            return result.strip() == "0x01" or result.strip() == "0x0000000000000000000000000000000000000000000000000000000000000001"
+    except requests.RequestException as e:
+        logger.error(f"Error in is_game_blacklisted for game {game_address}: {e}")
+        return False
 
 def send_email(title, msg, from_addr, to_addr, username, password):
     emsg = EmailMessage()
@@ -157,11 +189,21 @@ def main():
             blacklisted_count = 0  # Counter for blacklisted games
             msg = ""
 
-            bn = get_blocknumber(args.l1_rpc)
-            games = get_fdg_games(args.l1_rpc, args.fdg_factory, bn - args.blocks)
+            try:
+                bn = get_blocknumber(args.l1_rpc)
+                games = get_fdg_games(args.l1_rpc, args.fdg_factory, bn - args.blocks)
+            except Exception as e:
+                logger.error(f"Failed to get block number or games: {e}")
+                time.sleep(60)  # Wait a minute before retrying
+                continue
 
             for g in games:
                 info = get_fdg_game_info(args.l1_rpc, g["transactionHash"])
+                # Skip if blockNumber is 0 (indicating an error in getting game info)
+                if info["blockNumber"] == 0 or not info["output"]:
+                    logger.warning(f"Skipping game check due to missing data: {g['transactionHash']}")
+                    continue
+                    
                 l2output = get_l2output(args.l2_rpc, info["blockNumber"])
                 if l2output != "0x" + info["output"]:
                     # If the output roots don't match, check if the game is blacklisted

--- a/op/fdg_watcher.py
+++ b/op/fdg_watcher.py
@@ -154,6 +154,7 @@ def main():
         while True:
             logger.info("Checking")
             errors = 0
+            blacklisted_count = 0  # Counter for blacklisted games
             msg = ""
 
             bn = get_blocknumber(args.l1_rpc)
@@ -179,6 +180,7 @@ def main():
                         blacklisted = is_game_blacklisted(args.l1_rpc, args.optimism_portal2, game_address)
                         if blacklisted:
                             logger.info(f"Game {game_address} has output mismatch but is blacklisted, skipping alert")
+                            blacklisted_count += 1  # Increment blacklisted counter
                         else:
                             logger.info(f"Malicious Game {game_address} is not blacklisted")
                 
@@ -187,12 +189,12 @@ def main():
                             g["transactionHash"], game_address, l2output, info["output"])
                         errors += 1
 
-            msg += "total {}, successes {}, errors {}".format(len(games), len(games)-errors, errors)
+            msg += "total {}, successes {}, errors {}, blacklisted {}".format(len(games), len(games)-errors-blacklisted_count, errors, blacklisted_count)
 
             logger.info(msg)
 
             if errors != 0 or time.monotonic()-prev_send > args.force_interval:
-                title = "FDG {}, total {}, successes {}, errors {}".format(args.fdg_factory, len(games), len(games)-errors, errors)
+                title = "FDG {}, total {}, successes {}, errors {}, blacklisted {}".format(args.fdg_factory, len(games), len(games)-errors-blacklisted_count, errors, blacklisted_count)
                 send_email(title, msg, args.from_addr, args.to_addr, args.username, args.password)
                 prev_send = time.monotonic()
 

--- a/op/fdg_watcher.py
+++ b/op/fdg_watcher.py
@@ -171,7 +171,7 @@ def main():
     parser.add_argument("--to_addr", type=str, default="", help="email to address")
     parser.add_argument("--username", type=str, default="", help="email username")
     parser.add_argument("--password", type=str, default="", help="email password")
-    parser.add_argument("--test_email", type=bool, default=False, help="send a test email when start")
+    parser.add_argument("--test_email", action="store_true", help="send a test email when start")
     
     args = parser.parse_args()
 

--- a/op/fdg_watcher.py
+++ b/op/fdg_watcher.py
@@ -143,6 +143,7 @@ def main():
     parser.add_argument("--username", type=str, default="", help="email username")
     parser.add_argument("--password", type=str, default="", help="email password")
     parser.add_argument("--test_email", action="store_true", help="send a test email when start")
+
     args = parser.parse_args()
 
     # prev_balance = None


### PR DESCRIPTION
 - Fetch latest in-progress games at the start of the while loop
 - Use correct topic format for game creation events
 - Skip warning emails for blacklisted games
 - Add `title` parameter to `send_email` call
 - Add `--recipient` argument for test emails

In the scenario where a correct game is proposed but attacked by a malicious challenger, the attacker can only invalidate the correct game. They cannot finalize an incorrect game that would lead to fund loss. Therefore, we can deprioritize this case and focus on addressing the more critical scenario of a wrong game being proposed.

